### PR TITLE
feat: display count on Next example

### DIFF
--- a/examples/starknet-react-next/src/pages/index.tsx
+++ b/examples/starknet-react-next/src/pages/index.tsx
@@ -17,11 +17,19 @@ const Home: NextPage = () => {
       <h2>Counter Contract</h2>
       <p>Address: {counter?.connectedTo}</p>
       <p>Value: {counterValue?.count}</p>
+      <p>
+        Count:{' '}
+        {typeof counterValue?.count === 'string' && hexadecimalToDecimal(counterValue?.count)}
+      </p>
       <IncrementCounter />
       <h2>Recent Transactions</h2>
       <TransactionList />
     </div>
   )
+}
+
+function hexadecimalToDecimal(hexString: string): number {
+  return parseInt(hexString, 16)
 }
 
 export default Home


### PR DESCRIPTION
### Motivation

I couldn't easily tell if the Value was being incremented after I clicked the increment button. It was difficult for me to compare the hexadecimal values displayed in the **Value:** field. Therefore, this change displays the counter's count in decimal representation.

### Screenshot
<img width="589" alt="Screen Shot 2022-03-10 at 11 59 30 AM" src="https://user-images.githubusercontent.com/3699047/157715866-7a71017a-8d46-4df7-a9ac-a1c8e769da5b.png">

